### PR TITLE
Fix flipIn animation not working on re-render

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -116,7 +116,7 @@ function App() {
             Click each card once to earn points! Don&apos;t click the same card
             twice, and keep an eye on your score!
           </p>
-          <Cards onClick={cardClickHandler} characters={characters} />
+          <Cards key={currentScore} onClick={cardClickHandler} characters={characters} />
         </>
       )}
       <footer>


### PR DESCRIPTION
Passing  `currentScore` as a key to `Cards` component fixes the problem of some cards not being animated on re-render. Passing `currentScore` as a key tells React that each `Cards` component is conceptually a different one.
Whenever `currentScore` changes, the `Cards` component is re-created, and, in turn, its child `Card` components.